### PR TITLE
Fix selection can be undefined when first initialize quill with content without focusing on editor

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -225,6 +225,7 @@ class MarkdownShortcuts {
 
   onSpace () {
     const selection = this.quill.getSelection()
+    if (!selection) return
     const line = this.quill.getLine(selection.index)
     const text = line[0].domNode.textContent
     if (typeof text !== 'undefined' && text) {


### PR DESCRIPTION
Thanks for this library :). I notice quill.getSelection() can return null if the editor doesn't have focus, so this PR simply checks for that.