### PR TITLE
Fix Quill external config name

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,7 +12,7 @@ module.exports = {
         library: 'MarkdownShortcuts'
     },
     externals: {
-        quill: 'Quill',
+        quill: 'quill',
     },
     module: {
         loaders: [


### PR DESCRIPTION
Hello!

We are getting error of compilation due to a typo in the Webpack config while running our project:
```javascript
Cannot find file: 'quill.js' does not match the corresponding name on disk: '/PATH/node_modules/Quill/dist/quill'.
```

Thanks again for the awesome project!